### PR TITLE
Avoiding non CData elements to be split

### DIFF
--- a/XliffLib.Test/CDataSplitterTests.cs
+++ b/XliffLib.Test/CDataSplitterTests.cs
@@ -20,6 +20,30 @@ namespace XliffLib.Test
             return stream;
         }
 
+		[Test()]
+		public void PlainTextUnitIsNotSplit()
+		{
+			var xliff = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<xliff srcLang=""en-GB"" version=""2.0"" xmlns=""urn:oasis:names:tc:xliff:document:2.0"">
+    <file id=""f1"">
+        <unit id=""u1"">
+            <segment>
+                <source>Hello Word!</source>
+            </segment>
+        </unit>
+    </file>
+</xliff>";
+
+			XliffDocument document = LoadXliff(xliff);
+			var splitter = new CDataSplitter();
+
+			var newDocument = splitter.ExecuteExtraction(document);
+
+			Assert.AreEqual(1, newDocument.Files[0].Containers.Count);
+			var unit = newDocument.Files[0].Containers[0] as Unit;
+			Assert.IsNotNull(unit);
+
+		}
 
         [Test()]
         public void SingleParagraphUnitIsNotSplit()

--- a/XliffLib/CDataSplitter.cs
+++ b/XliffLib/CDataSplitter.cs
@@ -25,6 +25,7 @@ namespace XliffLib
                     if (segment != null)
                     {
                         var cdata = segment.Source.Text[0] as CDataTag;
+                        if (cdata == null) continue;
                         var html = cdata.Text;
                         var paragraphs = html.SplitByParagraphs();
                         if (paragraphs.Count() > 1)


### PR DESCRIPTION
Probably it would be a good idea to add some other method to also deal with splitting in more units also plain text properties

Solves issue #9 